### PR TITLE
docs: consistency, tone, and language polish across all pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .next
 node_modules
-Legal

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .next
 node_modules
+Legal

--- a/src/content/_meta.js
+++ b/src/content/_meta.js
@@ -2,7 +2,7 @@ module.exports = {
     "index" : "Introduction",
     "packages" : "Packages",
     "forest-cli" : "Forest CLI",
-    "legal" : "Policies"
+    "legal" : "Legal"
 }
 
 /*

--- a/src/content/_meta.js
+++ b/src/content/_meta.js
@@ -1,5 +1,8 @@
 module.exports = {
     "index" : "Introduction",
+    "packages" : "Packages",
+    "forest-cli" : "Forest CLI",
+    "legal" : "Policies"
 }
 
 /*

--- a/src/content/_meta.js
+++ b/src/content/_meta.js
@@ -2,11 +2,12 @@ module.exports = {
     "index" : "Introduction",
     "packages" : "Packages",
     "forest-cli" : "Forest CLI",
-    "legal" : "Legal"
+    "legal" : "Legal",
+    "faq" : "FAQ"
 }
 
 /*
-- Introduction (What is a package manager, why use one)
+- Introduction (What is a package manager , why use one)
 - Using a package (Finding, installing, updating, removing)
 - Creating a package (creation, publishing, updating)
 

--- a/src/content/faq/_meta.js
+++ b/src/content/faq/_meta.js
@@ -1,3 +1,3 @@
 module.exports = {
-    "commonly-asked-questions" : "Commonly asked Questions"
+    "commonly-asked-questions" : "Commonly Asked Questions"
 }

--- a/src/content/faq/_meta.js
+++ b/src/content/faq/_meta.js
@@ -1,0 +1,3 @@
+module.exports = {
+    "commonly-asked-questions" : "Commonly asked Questions"
+}

--- a/src/content/faq/commonly-asked-questions.mdx
+++ b/src/content/faq/commonly-asked-questions.mdx
@@ -20,3 +20,4 @@ Importing those packages will require using their full names to avoid ambiguity:
 ```lua
 local Package1 = require("user1_package")
 local Package2 = require("user2_package")
+```

--- a/src/content/faq/commonly-asked-questions.mdx
+++ b/src/content/faq/commonly-asked-questions.mdx
@@ -1,0 +1,22 @@
+## Commonly Asked Questions
+> What happens if two packages depend on the same package?
+
+Forest PM uses a technique called "dependency de-duplication" to ensure that if multiple packages depend on the same package, only one copy of that package is installed. This helps to reduce disk space usage and avoid version conflicts.
+
+> What if two packages depend on different versions of the same package?
+
+In cases where two packages depend on different versions of the same package, Forest PM will install both versions in separate folders within the `packages` directory. 
+
+This allows each package to use the version it was designed to work with, preventing compatibility issues. However, this can lead to increased disk space usage, so it's generally recommended to use packages that depend on compatible versions of shared dependencies whenever possible.
+
+> What happens if I install 2 packages with the same name?
+
+If you attempt to install two packages with the same name but from different authors or sources, Forest PM will treat them as separate entities based on their full package identifiers (which typically include the author's namespace).
+
+This means you can have `@user1/package` and `@user2/package` installed simultaneously without conflict, as they are considered distinct packages.
+
+Importing those packages will require using their full names to avoid ambiguity:
+
+```lua
+local Package1 = require("user1_package")
+local Package2 = require("user2_package")

--- a/src/content/forest-cli/commands.mdx
+++ b/src/content/forest-cli/commands.mdx
@@ -1,6 +1,6 @@
 # Forest CLI Commands
 
-The Forest CLI provides commands to help you manage your Forest projects and packages.
+The Forest CLI provides commands to help you manage your packages.
 
 ## Commands
 
@@ -18,22 +18,22 @@ Created forest.json
 ```
 
 ### `forest install <package-name>`
-Installs a package from Forest. Downloads the package and its dependencies into your project’s packages directory.
+Installs a package from Forest PM. Downloads the package and its dependencies into your project’s packages directory.
 
 Alias: `forest i <package-name>`
 
 ### `forest uninstall <package-name>`
 
-Uninstalls a package from your project. Removes the package and its dependencies from your project’s packages directory.
+Uninstalls a package from your project. Removes the package and its dependencies from your project’s `packages` directory.
 
 Alias: `forest remove <package-name>`
 
 ### `forest publish`
 
-Publishes your package to Forest. Uploads the package and its metadata to the Forest registry, making it available for others to install.
+Publishes your package to Forest PM. Uploads the package and its metadata to the Forest PM registry, making it available for others to install.
 
 ### `forest login`
-Logs in to your Forest account. Prompts for username and password, then stores your authentication token locally.
+Logs in to your Forest PM account. Prompts for username and password, then stores your authentication token locally.
 
 The Forest CLI supports two-factor authentication (2FA). If enabled, you’ll be prompted for a 2FA code after entering your credentials.
 
@@ -47,8 +47,8 @@ Logged in as your-username
 ```
 
 ### `forest logout`
-Logs out of your Forest account and removes the local authentication token.
+Logs out of your Forest PM account and removes the local authentication token.
 
 ### `forest whoami`
 
-Displays the currently logged-in user for the active Forest account.
+Displays the currently logged-in user for the active Forest PM account.

--- a/src/content/forest-cli/commands.mdx
+++ b/src/content/forest-cli/commands.mdx
@@ -1,13 +1,13 @@
 # Forest CLI Commands
 
-The Forest CLI provides a variety of commands to help you manage your Forest projects.
+The Forest CLI provides commands to help you manage your Forest projects and packages.
 
 ## Commands
 
 
 ### `forest init`
 
-Initializes a new Forest package in the current directory. This command creates a `forest.json` file that contains metadata about your package, such as its name, version, and description.
+Initializes a new package in the current directory. This creates a `forest.json` file with metadata such as name, version, and description.
 
 ```bash
 forest init
@@ -18,24 +18,24 @@ Created forest.json
 ```
 
 ### `forest install <package-name>`
-Installs a package from the Forest Package Manager. This command downloads the package and its dependencies and adds them to your project's `packages` directory.
+Installs a package from Forest. Downloads the package and its dependencies into your project’s packages directory.
 
 Alias: `forest i <package-name>`
 
 ### `forest uninstall <package-name>`
 
-Uninstalls a package from your project. This command removes the package and its dependencies from your project's `packages` directory.
+Uninstalls a package from your project. Removes the package and its dependencies from your project’s packages directory.
 
 Alias: `forest remove <package-name>`
 
 ### `forest publish`
 
-Publishes your package to the Forest Package Manager. This command uploads your package and its metadata to the Forest PM registry, making it available for others to install and use.
+Publishes your package to Forest. Uploads the package and its metadata to the Forest registry, making it available for others to install.
 
 ### `forest login`
-Logs in to your Forest PM account. This command prompts you for your username and password and stores your authentication token locally.
+Logs in to your Forest account. Prompts for username and password, then stores your authentication token locally.
 
-The Forest CLI has built-in support for two-factor authentication (2FA). If your account has 2FA enabled, you'll be prompted to enter your 2FA code after entering your username and password.
+The Forest CLI supports two-factor authentication (2FA). If enabled, you’ll be prompted for a 2FA code after entering your credentials.
 
 ```bash
 forest login
@@ -47,8 +47,8 @@ Logged in as your-username
 ```
 
 ### `forest logout`
-Logs out of your Forest PM account. This command removes your authentication token from your local machine.
+Logs out of your Forest account and removes the local authentication token.
 
 ### `forest whoami`
 
-Displays the currently logged-in user. This command shows your username for the Forest PM account.
+Displays the currently logged-in user for the active Forest account.

--- a/src/content/forest-cli/install.mdx
+++ b/src/content/forest-cli/install.mdx
@@ -2,7 +2,7 @@ import { Steps } from 'nextra/components'
 
 # Installing the Forest CLI
 
-The Forest CLI is your entry point into Forest workflows. It’s a lightweight tool that lets creators and teams manage packages and projects directly from the terminal.
+The Forest CLI is your entry point into the Forest PM ecosystem. It’s a lightweight tool that lets creators and teams manage packages and projects directly from the terminal.
 ## Installation Steps
 
 <Steps>
@@ -10,11 +10,11 @@ The Forest CLI is your entry point into Forest workflows. It’s a lightweight t
 
 For your operating system, visit the [Forest CLI installation page](https://forest.dev/download) and download the installer.
 
-Forest is not distributed via package managers or tool chain managers at this time.
+Forest PM is not distributed via package managers or tool chain managers at this time.
 
 ### Run the Installer
 
-Follow the prompts in the installer to complete the installation. Forest CLI supports Windows, macOS, and Linux, so you can set up the same work flow in minutes on any platform. 
+Follow the prompts in the installer to complete the installation. Forest CLI supports Windows, macOS, and Linux, unifying your Forest PM workflow across all operating systems.
 
 ### Verify Installation
 

--- a/src/content/forest-cli/install.mdx
+++ b/src/content/forest-cli/install.mdx
@@ -2,8 +2,7 @@ import { Steps } from 'nextra/components'
 
 # Installing the Forest CLI
 
-The Forest CLI is a lightweight command-line interface tool that allows developers to interact with the Forest Package Manager from their terminal.
-
+The Forest CLI is your entry point into Forest workflows. It’s a lightweight tool that lets creators and teams manage packages and projects directly from the terminal.
 ## Installation Steps
 
 <Steps>
@@ -15,7 +14,7 @@ Forest is not distributed via package managers or tool chain managers at this ti
 
 ### Run the Installer
 
-Follow the prompts in the installer to complete the installation. Forest CLI supports Windows, macOS, and Linux.
+Follow the prompts in the installer to complete the installation. Forest CLI supports Windows, macOS, and Linux, so you can set up the same work flow in minutes on any platform. 
 
 ### Verify Installation
 
@@ -25,7 +24,7 @@ Open any terminal and run the following command to verify that the Forest CLI is
 forest --version
 ```
 
-You should see the version number of the Forest CLI printed in the terminal.
+If installed correctly, you should see the version number of the Forest CLI printed in the terminal.
 
 
 </Steps>

--- a/src/content/index.mdx
+++ b/src/content/index.mdx
@@ -2,9 +2,9 @@ import { Cards } from 'nextra/components'
 
 # Forest Package Manager
 
-What is Forest Package Manager? Forest Package Manager (Forest PM) is a cloud-based package manager that makes studio-grade workflows accessible to every creator.
+Forest Package Manager (Forest PM) is a cloud-based package manager that makes studio-grade workflows accessible to every creator.
 
-Built for creators and teams from day one, Forest lets you find and install packages without friction. More than a tool, it integrates smoothly into existing dev flows while giving new creators a professional foundation to build on.
+Built for creators and teams from day one, Forest PM lets you find and install packages without friction. More than a tool, it integrates smoothly into existing dev flows while giving creators a professional foundation to build on.
 
 ## Core features
 - **Cloud-based:** Access from anywhere—no local repositories to manage.

--- a/src/content/index.mdx
+++ b/src/content/index.mdx
@@ -7,7 +7,7 @@ Forest Package Manager (Forest PM) is a cloud-based package manager that makes s
 Built for creators and teams from day one, Forest PM lets you find and install packages without friction. More than a tool, it integrates smoothly into existing dev flows while giving creators a professional foundation to build on.
 
 ## Core features
-- **Cloud-based:** Access from anywhere—no local repositories to manage.
+- **Cloud-based:** Access from anywhere -- no local repositories to manage.
 - **Versioning:** Semantic versioning keeps packages compatible across your project.
 - **Dependency management:** Automatically manages dependencies between packages ensuring your projects are up to date.
 - **Collaboration:** Share packages across your team and manage access with Organizations.

--- a/src/content/index.mdx
+++ b/src/content/index.mdx
@@ -2,18 +2,17 @@ import { Cards } from 'nextra/components'
 
 # Forest Package Manager
 
-Forest Package Manager (Forest PM) is a cloud-based code package manager designed for immersive experience developers.
+What is Forest Package Manager? Forest Package Manager (Forest PM) is a cloud-based package manager that makes studio-grade workflows accessible to every creator.
 
-Forest PM is built from the ground up with immersive experience developers in mind. It is designed to be easy to use, with a simple and intuitive interface that makes it easy to find and install packages.
-Never before has an industry leading workflow been more accessible in the immersive experience space.
+Built for creators and teams from day one, Forest lets you find and install packages without friction. More than a tool, it integrates smoothly into existing dev flows while giving new creators a professional foundation to build on.
 
-Core features of Forest PM include:
-- **Cloud-based**: Forest PM is a cloud-based package manager, which means you can access it from anywhere and don't have to worry about managing local package repositories.
-- **Versioning**: Forest PM uses semantic versioning to ensure that packages are compatible with each other and with your project.
-- **Dependency management**: Forest PM automatically manages dependencies between packages, ensuring that all required packages are installed and up to date.
-- **Collaboration**: Forest PM makes it easy to share packages with your team and collaborate on projects with Organizations.
-- **Licensing**: Forest PM includes built-in support for managing package licenses, ensuring that you comply with open-source licensing requirements.
-- **Discoverability**: Forest PM includes a powerful package registry that makes it easy to find and discover new packages.
+## Core features
+- **Cloud-based:** Access from anywhere—no local repositories to manage.
+- **Versioning:** Semantic versioning keeps packages compatible across your project.
+- **Dependency management:** Automatically manages dependencies between packages ensuring your projects are up to date.
+- **Collaboration:** Share packages across your team and manage access with Organizations.
+- **Licensing:** Built-in license management helps teams stay compliant with open source requirements.
+- **Discoverability:** A searchable registry helps you quickly evaluate and adopt new packages.
 
 ## Quick Start
 

--- a/src/content/legal/_meta.js
+++ b/src/content/legal/_meta.js
@@ -1,0 +1,5 @@
+module.exports = {
+    "terms" : "Terms of Service",
+    "privacy-policy" : "Privacy Policy",
+    "dmca" : "DMCA Takedown Policy"
+}

--- a/src/content/legal/_meta.js
+++ b/src/content/legal/_meta.js
@@ -1,5 +1,5 @@
 module.exports = {
     "terms" : "Terms of Service",
     "privacy-policy" : "Privacy Policy",
-    "dmca" : "DMCA Takedown Policy"
+    "dmca" : "DMCA Policy"
 }

--- a/src/content/legal/dmca.mdx
+++ b/src/content/legal/dmca.mdx
@@ -6,12 +6,12 @@ Forest Software's Digital Millennium Copyright Act (DMCA) Policy
 v1.0.4 - 10.09.2025
 
 
-Forest Software LLC (“Forest”) respects the intellectual property rights of others and expects users of our Services to do the same.
+Forest Software respects the intellectual property rights of others and expects users of our Services to do the same.
 In accordance with the Digital Millennium Copyright Act (“DMCA”), we have adopted the following policy regarding copyright infringement;
 
 ## Designated DMCA Agent
 
-   Pursuant to 17 U.S.C. §512(c), Forest has designated the following agent to receive notifications of alleged infringement.
+   Pursuant to 17 U.S.C. §512(c), Forest Software has designated the following agent to receive notifications of alleged infringement.
    Laurence S. Donahue, Esq.
    L4SB
    6801 Jefferson St. NE, Ste. 220
@@ -45,23 +45,23 @@ In accordance with the Digital Millennium Copyright Act (“DMCA”), we have ad
 ## Notice–Takedown–Putback Process
 
     ##### Notice Received (Day 0)
-    When Forest receives a valid DMCA notice, the identified content is promptly **disabled or removed**. Forest then notifies the user who posted or uploaded the content, providing them a copy of the notice and instructions on how to submit a counter-notification.
+    When Forest Software receives a valid DMCA notice, the identified content is promptly **disabled or removed**. Forest Software then notifies the user who posted or uploaded the content, providing them a copy of the notice and instructions on how to submit a counter-notification.
 
     ##### Takedown Period (Up to 30 Days)
-    The removed content remains in an **inactive state** — not publicly visible, excluded from search results and user profiles — while Forest awaits either:
+    The removed content remains in an **inactive state** — not publicly visible, excluded from search results and user profiles — while Forest Software awaits either:
         * a counter-notification from the user; or
         * confirmation that the complainant has filed a court action.
         If **no counter-notification** is received within 30 days, the content is permanently deleted per the Retention Policy below.
 
     ##### Counter-Notification (If Submitted)
-    If a proper counter-notification is received, Forest forwards it to the original complainant within a reasonable time (typically 1–2 business days).
+    If a proper counter-notification is received, Forest Software forwards it to the original complainant within a reasonable time (typically 1–2 business days).
 
     ##### Put-Back Window (10–14 Business Days)
-    Unless the complainant notifies Forest within **10 business days** that they have filed a federal lawsuit seeking to restrain the alleged infringement, Forest will **restore or re-enable** the content between 10 and 14 business days after forwarding the counter-notice.
+    Unless the complainant notifies Forest Software within **10 business days** that they have filed a federal lawsuit seeking to restrain the alleged infringement, Forest Software will **restore or re-enable** the content between 10 and 14 business days after forwarding the counter-notice.
 
     ##### Case Closure
-        * If a lawsuit is filed and Forest receives evidence of it within the 10-day window, the content remains disabled pending court resolution.
-        * If no such notice is received, Forest restores the material and considers the matter closed.
+        * If a lawsuit is filed and Forest Software receives evidence of it within the 10-day window, the content remains disabled pending court resolution.
+        * If no such notice is received, Forest Software restores the material and considers the matter closed.
 
     ##### Retention Policy
         * **Inactive status:** Content removed in response to a DMCA notice will remain disabled, hidden from public view, and excluded from search results and user profiles until the DMCA process is fully resolved.
@@ -69,8 +69,8 @@ In accordance with the Digital Millennium Copyright Act (“DMCA”), we have ad
 
 ## Repeat Infringers
 
-   Forest will, in appropriate circumstances, terminate user accounts that are deemed to be repeat infringers.
+   Forest Software will, in appropriate circumstances, terminate user accounts that are deemed to be repeat infringers.
 
 ## Reservation of Rights
 
-   Forest reserves the right to remove or disable access to any content alleged to be infringing without prior notice and at our sole discretion.
+   Forest Software reserves the right to remove or disable access to any content alleged to be infringing without prior notice and at our sole discretion.

--- a/src/content/legal/dmca.mdx
+++ b/src/content/legal/dmca.mdx
@@ -1,4 +1,4 @@
-# DMCA Takedown Policy
+# DMCA Policy
 
 Forest Software's Digital Millennium Copyright Act (DMCA) Policy
 

--- a/src/content/legal/dmca.mdx
+++ b/src/content/legal/dmca.mdx
@@ -1,0 +1,76 @@
+# DMCA Takedown Policy
+
+Forest Software's Digital Millennium Copyright Act (DMCA) Policy
+
+---
+v1.0.4 - 10.09.2025
+
+
+Forest Software LLC (“Forest”) respects the intellectual property rights of others and expects users of our Services to do the same.
+In accordance with the Digital Millennium Copyright Act (“DMCA”), we have adopted the following policy regarding copyright infringement;
+
+## Designated DMCA Agent
+
+   Pursuant to 17 U.S.C. §512(c), Forest has designated the following agent to receive notifications of alleged infringement.
+   Laurence S. Donahue, Esq.
+   L4SB
+   6801 Jefferson St. NE, Ste. 220
+   +1-505-715-5700
+   [LegalResponseTeam@L4SB.com](mailto:LegalResponseTeam@L4SB.com)
+   This contact information is also registered with the U.S. Copyright Office.
+
+## Notification of Claimed Infringement
+
+   If you believe your copyrighted work has been infringed, please submit a written notice to our Designated Agent that includes all elements required under 17 U.S.C. §512(c)(3);
+   2a. A physical or electronic signature of the copyright owner or authorized representative.
+   2b. Identification of the copyrighted work claimed to have been infringed.
+   2c. Identification of the allegedly infringing material and information reasonably sufficient to locate it. The easiest way to do this is by providing web addresses (URLs) leading directly to the allegedly infringing content.
+   2d. Your contact information including full name, current address, and an active telephone number and email address.
+   2e. A statement that you have a good-faith belief the disputed use is not authorized by the copyright owner, its agent, or the law.
+   2f. A statement that the information in the notice is accurate and, under penalty of perjury, that you are authorized to act on behalf of the copyright owner.
+   Upon receipt of a proper claim of copyright infringement as identified above, we will work to expeditiously remove or disable access to the claimed infringing material.
+
+## Counter-Notification
+
+   If you believe your content was removed or disabled in error, you may submit a counter-notice to our Designated Agent. The following information is required under 17 U.S.C. §512(g)(3) to be deemed a proper counter-notification (submitted to our Designated Agent identified above);
+   3a. Your physical or electronic signature.
+   3b. Identification of the material that has been removed or disabled and its original location.
+   3c. A statement under penalty of perjury that you have a good-faith belief the material was removed or disabled as a result of mistake or misidentification.
+   3d. Your name, address, and telephone number, and a statement that you consent to the jurisdiction of the federal court for the judicial district in which your address is located (or if outside the U.S., that you consent to jurisdiction in the federal courts located in Travis County, Texas), and that you will accept service of process from the person who submitted the original notice.
+
+## Post-Counter-Notification Process
+
+   Upon receipt of a proper counter-notice, we will supply the person who provided the original claim of copyright infringement with a copy of the counter-notice, and we will replace the removed content or cease disabling access to the content not less than 10 business days, and not more than 14 business days, UNLESS our Designated Agent (identified above) first receives notice from the person who provided the original claim of copyright infringement that such person has filed an action seeking a court order to restrain the individual (or entity) in control of the alleged infringing content, from engaging in infringing activity related to the content located on our website.
+
+## Notice–Takedown–Putback Process
+
+    ##### Notice Received (Day 0)
+    When Forest receives a valid DMCA notice, the identified content is promptly **disabled or removed**. Forest then notifies the user who posted or uploaded the content, providing them a copy of the notice and instructions on how to submit a counter-notification.
+
+    ##### Takedown Period (Up to 30 Days)
+    The removed content remains in an **inactive state** — not publicly visible, excluded from search results and user profiles — while Forest awaits either:
+        * a counter-notification from the user; or
+        * confirmation that the complainant has filed a court action.
+        If **no counter-notification** is received within 30 days, the content is permanently deleted per the Retention Policy below.
+
+    ##### Counter-Notification (If Submitted)
+    If a proper counter-notification is received, Forest forwards it to the original complainant within a reasonable time (typically 1–2 business days).
+
+    ##### Put-Back Window (10–14 Business Days)
+    Unless the complainant notifies Forest within **10 business days** that they have filed a federal lawsuit seeking to restrain the alleged infringement, Forest will **restore or re-enable** the content between 10 and 14 business days after forwarding the counter-notice.
+
+    ##### Case Closure
+        * If a lawsuit is filed and Forest receives evidence of it within the 10-day window, the content remains disabled pending court resolution.
+        * If no such notice is received, Forest restores the material and considers the matter closed.
+
+    ##### Retention Policy
+        * **Inactive status:** Content removed in response to a DMCA notice will remain disabled, hidden from public view, and excluded from search results and user profiles until the DMCA process is fully resolved.
+        * **Retention period:** Removed content will be retained in our systems for 30 days from the date of removal. If the dispute is not resolved or no counter-notice is filed within that period, the violating content will be permanently deleted.
+
+## Repeat Infringers
+
+   Forest will, in appropriate circumstances, terminate user accounts that are deemed to be repeat infringers.
+
+## Reservation of Rights
+
+   Forest reserves the right to remove or disable access to any content alleged to be infringing without prior notice and at our sole discretion.

--- a/src/content/legal/privacy-policy.mdx
+++ b/src/content/legal/privacy-policy.mdx
@@ -55,8 +55,7 @@ We may retain certain data as required by law, for legitimate business purposes,
 - **GDPR (EU/EEA Users):** You have the right to request access, correction, deletion, restriction of processing, data portability, and to object to certain processing. You may also lodge a complaint with your local supervisory authority.
 - **CCPA/CPRA (California Users):** You have the right to request to know what personal information we collect, to request deletion, and to opt-out of any sale or sharing of personal information. We do not sell personal information.
 
-> **TODO:** Need dedicated privacy email; reach out to mr.architect <br/>
-To exercise these rights, contact us at **privacy@[yourdomain].com**. We may require verification of your identity before fulfilling your request.
+To exercise these rights, contact us at legal@forest.dev. We may require verification of your identity before fulfilling your request.
 
 ## Children’s Privacy
 The Services are not directed to children under 13, and we do not knowingly collect personal information from them. Users between 13–18 must have parental or guardian consent.
@@ -68,7 +67,7 @@ Your information may be stored and processed in the United States. By using the 
 We may update this Privacy Policy from time to time. If changes are material, we will notify you by email or within the Services. Continued use after changes take effect means you accept the updated policy.
 
 ## Contact Us
-Forest Software, LLC  
-5900 Balcones Dr STE 100
-Austin, TX
-Email: **privacy@[yourdomain].com*
+Forest Sofware LLC
+5900 Balcones Dr, STE 100 <br />
+Austin, TX 78731 <br />
+Email: legal@forest.dev

--- a/src/content/legal/privacy-policy.mdx
+++ b/src/content/legal/privacy-policy.mdx
@@ -1,7 +1,7 @@
 # Privacy Policy
 **Effective Date:** 9/30/2025
 
-Forest Software, LLC ("Forest", "we", "our", or "us") values your privacy. This Privacy Policy explains how we collect, use, and protect your information when you use our developer tools, including the Forest CLI and any future components such as the Forest Studio Plugin (collectively, the “Services”).
+Forest Software, LLC ("Forest Software", "we", "our", or "us") values your privacy. This Privacy Policy explains how we collect, use, and protect your information when you use our developer tools, including the Forest Software CLI and any future components such as the Forest Software Studio Plugin (collectively, the “Services”).
 
 By using the Services, you agree to the terms of this Privacy Policy.
 
@@ -32,7 +32,7 @@ We may share limited data with:
 
 - **Vendors/Service Providers**: such as hosting (e.g., AWS), payment processors (e.g., Stripe), analytics providers, and AI providers (e.g., OpenAI for metadata processing of public packages).
 - **Legal/Compliance**: if required by law, court order, or to respond to copyright infringement notices.
-- **Business Transfers**: if Forest is involved in a merger, acquisition, or sale of assets.
+- **Business Transfers**: if Forest Software is involved in a merger, acquisition, or sale of assets.
 
 ## Security
 We implement reasonable technical and organizational measures to protect information, including:
@@ -48,6 +48,9 @@ No system is perfectly secure, and we cannot guarantee absolute protection.
 - **Audit Logs**: retained for as long as your organization account is active, or as required by law.
 - **Credentials**: removed upon account deletion.
 - **Packages**: may persist unless removed by the package author.
+
+
+We process and retain limited identifiers (e.g., public username in package metadata) under GDPR Art. 6(1)(f) legitimate interests, to ensure package integrity and dependency resolution.
 
 We may retain certain data as required by law, for legitimate business purposes, or for dispute resolution.
 
@@ -67,7 +70,7 @@ Your information may be stored and processed in the United States. By using the 
 We may update this Privacy Policy from time to time. If changes are material, we will notify you by email or within the Services. Continued use after changes take effect means you accept the updated policy.
 
 ## Contact Us
-Forest Sofware LLC
+Forest Software, LLC <br />
 5900 Balcones Dr, STE 100 <br />
 Austin, TX 78731 <br />
 Email: legal@forest.dev

--- a/src/content/legal/privacy-policy.mdx
+++ b/src/content/legal/privacy-policy.mdx
@@ -1,0 +1,74 @@
+# Privacy Policy
+**Effective Date:** 9/30/2025
+
+Forest Software, LLC ("Forest", "we", "our", or "us") values your privacy. This Privacy Policy explains how we collect, use, and protect your information when you use our developer tools, including the Forest CLI and any future components such as the Forest Studio Plugin (collectively, the “Services”).
+
+By using the Services, you agree to the terms of this Privacy Policy.
+
+## Information We Collect
+We may collect the following categories of information:
+
+- **Account Information**: email, username, hashed password.
+- **Authentication Data**: OAuth tokens or API keys (encrypted at rest).
+- **Usage Data**: anonymized analytics, package metadata (names, descriptions, README files), and logs of CLI/Service activity.
+- **Organization Data**: private audit logs tied to your organization’s account.
+- **Payment Information**: billing details processed securely by third-party payment providers (e.g., Stripe, PayPal). We do not store full credit card numbers.
+- **Content Data**: code, packages, or assets you upload to share.
+
+## How We Use Information
+We use collected information to:
+
+- Provide, operate, and improve the Services.
+- Authenticate users and secure accounts.
+- Process payments for subscriptions and purchases.
+- Improve discovery and recommendations (e.g., AI analysis of public package metadata).
+- Maintain organizational audit logs.
+- Detect, prevent, and respond to abuse or legal obligations (e.g., DMCA requests).
+
+## Sharing of Information
+We do not sell personal information.
+
+We may share limited data with:
+
+- **Vendors/Service Providers**: such as hosting (e.g., AWS), payment processors (e.g., Stripe), analytics providers, and AI providers (e.g., OpenAI for metadata processing of public packages).
+- **Legal/Compliance**: if required by law, court order, or to respond to copyright infringement notices.
+- **Business Transfers**: if Forest is involved in a merger, acquisition, or sale of assets.
+
+## Security
+We implement reasonable technical and organizational measures to protect information, including:
+
+- Encryption in transit (TLS).
+- Encryption at rest for sensitive data such as OAuth tokens.
+- Industry-standard password hashing for account credentials.
+
+No system is perfectly secure, and we cannot guarantee absolute protection.
+
+## Data Retention
+- **Accounts**: retained until you request deletion.
+- **Audit Logs**: retained for as long as your organization account is active, or as required by law.
+- **Credentials**: removed upon account deletion.
+- **Packages**: may persist unless removed by the package author.
+
+We may retain certain data as required by law, for legitimate business purposes, or for dispute resolution.
+
+## Your Privacy Rights
+- **GDPR (EU/EEA Users):** You have the right to request access, correction, deletion, restriction of processing, data portability, and to object to certain processing. You may also lodge a complaint with your local supervisory authority.
+- **CCPA/CPRA (California Users):** You have the right to request to know what personal information we collect, to request deletion, and to opt-out of any sale or sharing of personal information. We do not sell personal information.
+
+> **TODO:** Need dedicated privacy email; reach out to mr.architect <br/>
+To exercise these rights, contact us at **privacy@[yourdomain].com**. We may require verification of your identity before fulfilling your request.
+
+## Children’s Privacy
+The Services are not directed to children under 13, and we do not knowingly collect personal information from them. Users between 13–18 must have parental or guardian consent.
+
+## International Users
+Your information may be stored and processed in the United States. By using the Services, you consent to this transfer. If you are located outside the U.S., note that your data may be subject to U.S. laws.
+
+## Changes to this Policy
+We may update this Privacy Policy from time to time. If changes are material, we will notify you by email or within the Services. Continued use after changes take effect means you accept the updated policy.
+
+## Contact Us
+Forest Software, LLC  
+5900 Balcones Dr STE 100
+Austin, TX
+Email: **privacy@[yourdomain].com*

--- a/src/content/legal/terms.mdx
+++ b/src/content/legal/terms.mdx
@@ -80,7 +80,7 @@ with the U.S. Copyright Office.
 
 Your notice must include the required information under 17 U.S.C. § 512(c)(3).
 We may remove or disable access to reported content and may terminate repeat infringers.
-For more information, see our [DMCA Takedown Policy](/legal/dmca).
+For more information, see our [DMCA Policy](/legal/dmca).
 
 
 ## 10. Intellectual Property (Ours)

--- a/src/content/legal/terms.mdx
+++ b/src/content/legal/terms.mdx
@@ -1,0 +1,133 @@
+
+
+# Terms of Service
+
+These Terms of Service govern your access to and use of developer tools provided by Forest Software, LLC ("Forest", "we", "our", or "us").
+
+
+
+## 1. Eligibility
+
+You must be at least **13 years old** to use the Service. If you are using the Service on behalf of a Forest or organization, you represent that you have authority to bind that entity to these Terms.
+
+
+## 2. Accounts & Security
+
+You may need an account to use some features. You’re responsible for keeping your credentials confidential and for actions taken using your account. You must provide accurate information and keep it current. We may require email verification or multi‑factor authentication.
+
+
+## 3. Software License (CLI & Plugin)
+
+Subject to these Terms, Forest grants you a limited, revocable, non‑exclusive, non‑transferable license to install and use the CLI and plugin solely to build with and for the Service. You may not: (a) copy, modify, or create derivative works of the software; (b) reverse engineer or attempt to extract source code except where permitted by law; (c) bypass, remove, or circumvent any security or technical measures; (d) resell, rent, or lease the Service unless we give you written permission.
+
+
+## 4. Third‑Party Services & APIs
+
+The Service may interact with third‑party platforms and APIs (e.g., **Roblox**). You are solely responsible for compliance with any third‑party terms, policies, and developer rules. We are not affiliated with or endorsed by such third parties, and we make no warranties about their services. We may disable integrations that violate third‑party terms or legal requirements.
+
+
+## 5. User Content
+
+**Ownership.** You retain ownership of code, assets, and other content you submit or upload through the Service (“User Content”).  
+**License to Us.** You grant Forest a non‑exclusive, worldwide, royalty‑free license to host, store, process, transmit, and display your User Content **solely to provide and operate** the Service and as you otherwise instruct (e.g., sharing or distribution features you use).  
+**Your Responsibilities.** You are responsible for your User Content and for ensuring you have the rights to submit it. Do not upload content that is illegal or that infringes others’ rights.  
+**Visibility & Org Access.** If you use an organization account, designated org admins may access audit logs and certain usage information associated with your account as described in our Privacy Policy.
+
+## 5.1 Use of AI Services
+
+We use third-party AI providers (such as OpenAI) to process package metadata, including but not limited to package names, descriptions, and README files. This processing is done only for public packages and is used to improve search, discovery, and recommendations within Forest. By uploading a public package, you grant Forest a non-exclusive, worldwide license to analyze and process its metadata for these purposes. This license is limited to enabling functionality within Forest and does not authorize us or our AI providers to redistribute or commercialize your content beyond what is necessary to provide the service. You are responsible for ensuring that your submissions (including README and metadata) do not infringe on third-party rights, contain sensitive personal information, or otherwise violate applicable laws or these Terms. Private packages are never sent to external AI providers.
+
+
+## 6. Acceptable Use
+
+You agree not to misuse the Service. For example, you will not: (a) violate laws or third‑party rights; (b) attempt to gain unauthorized access to accounts, systems, or data; (c) interfere with the Service’s operation; (d) deploy malware, spam, or automated abuse; (e) use the Service for exploitation or harassment; (f) circumvent rate limits; (g) engage in high‑risk activities where failure could lead to death or injury. We may investigate and suspend accounts for suspected violations.
+
+
+## 7. Moderation & Reporting
+
+We **do not pre-screen** User Content before it is made available. Instead, we provide community reporting tools — including a form to report packages — and may use automated filters to flag obvious abuse.
+
+We may remove or disable access to any content, or suspend or terminate accounts, where we in good faith believe these Terms, our Acceptable Use Policy, or applicable law are violated (including repeat infringement under Section 10).
+
+We are **not obligated to monitor all content** and make no guarantees that all objectionable or unlawful content will be removed. Users are encouraged to use the reporting tools to help us maintain a safe and compliant environment.
+
+
+## 8. Fees and Payment
+
+You agree to pay all fees associated with your subscription or purchase in accordance with the pricing and billing terms presented to you at the time of purchase.
+
+**All payments are non-refundable and non-transferable**, except as required by applicable law. This includes, without limitation, situations where you cancel your subscription before the end of a billing period.
+
+Your subscription will automatically renew at the end of each billing cycle unless you cancel before the renewal date. You may cancel at any time, but cancellation will only prevent future charges; you will not receive a refund for amounts already paid.
+
+We reserve the right to modify pricing or billing terms with reasonable advance notice to you (typically by email or within the Service). Continued use of the Service after such notice constitutes your agreement to the updated terms.
+
+
+## 9. Copyright & IP Infringement (DMCA)
+
+If you believe content available through the Service infringes your copyrights,
+please submit a notice to our designated DMCA Agent:
+
+**DMCA Agent:** Laurence S. Donahue, Esq.  
+**Firm:** L4SB  
+**Mailing Address:** 6801 Jefferson St. NE, Ste. 220  
+**Phone:** +1-505-715-5700  
+**Email:** [LegalResponseTeam@L4SB.com](mailto:LegalResponseTeam@L4SB.com)  
+
+Pursuant to 17 U.S.C. §512(c), Forest has designated the above agent to receive
+notifications of alleged infringement. This contact information is also registered
+with the U.S. Copyright Office.
+
+Your notice must include the required information under 17 U.S.C. § 512(c)(3).
+We may remove or disable access to reported content and may terminate repeat infringers.
+For more information, see our [DMCA Takedown Policy](/policies/dmca).
+
+
+## 10. Intellectual Property (Ours)
+
+The Service, software, documentation, and brand assets are owned by Forest and its licensors. Except for the limited license in Section 5, we grant no rights to our IP. Feedback is voluntary; we may use it without restriction.
+
+
+## 11. Termination
+
+You may stop using the Service at any time. We may suspend or terminate your access immediately if you materially breach these Terms, create risk or possible legal exposure for us, or use the Service in a way that could disrupt others. Upon termination, your right to use the Service ends, but Sections 5, 6 (as to licenses needed to operate the Service, e.g., limited back‑ups), 9–20 survive.
+
+
+## 12. Disclaimers
+
+THE SERVICE IS PROVIDED **“AS IS”** AND **“AS AVAILABLE.”** TO THE MAXIMUM EXTENT PERMITTED BY LAW, WE DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON‑INFRINGEMENT. We do not warrant that the Service will be uninterrupted, secure, or error‑free, or that content will be preserved without loss.
+
+
+## 13. Limitation of Liability
+
+TO THE MAXIMUM EXTENT PERMITTED BY LAW, Forest AND ITS AFFILIATES, SUPPLIERS, AND LICENSORS WILL NOT BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, OR ANY LOSS OF PROFITS, REVENUE, DATA, OR USE, EVEN IF ADVISED OF THE POSSIBILITY. OUR AGGREGATE LIABILITY FOR ALL CLAIMS RELATING TO THE SERVICE WILL NOT EXCEED THE GREATER OF **(A) THE AMOUNTS YOU PAID TO US FOR THE SERVICE IN THE 12 MONTHS BEFORE THE CLAIM** OR **(B) US $100.** Some jurisdictions don’t allow certain limits; these may not apply to you.
+
+
+## 14. Indemnity
+
+You will indemnify and hold Forest harmless from any claim arising from your use of the Service or User Content that violates law or third‑party rights.
+
+
+## 15. Export & Sanctions
+
+You may not use the Service if you are located in, or are a resident of, a country or region embargoed by the U.S., or if you are on any U.S. government list of restricted parties. You agree to comply with applicable export control and sanctions laws.
+
+
+## 16. Disputes; Governing Law
+
+These Terms are governed by the laws of the State of Texas, USA, without regard to conflict-of-laws rules.  
+
+You and Forest consent to Travis County, Texas as the exclusive venue for any permitted court proceedings.  
+
+
+## 17. Changes to the Service or Terms
+
+We may modify the Service and these Terms. For material changes, we will provide notice (e.g., email or in‑app) and the changes will take effect prospectively. If you continue using the Service after the effective date, you accept the changes.
+
+
+## 18. Contact
+
+Forest Sofware LLC
+5900 Balcones Dr, STE 100 <br />
+Austin, TX 78731 <br />
+Email: [hi@forest.dev](mailto:hi@forest.dev)

--- a/src/content/legal/terms.mdx
+++ b/src/content/legal/terms.mdx
@@ -2,13 +2,13 @@
 
 # Terms of Service
 
-These Terms of Service govern your access to and use of developer tools provided by Forest Software, LLC ("Forest", "we", "our", or "us").
+These Terms of Service govern your access to and use of developer tools provided by Forest Software, LLC ("Forest Software", "we", "our", or "us").
 
 
 
 ## 1. Eligibility
 
-You must be at least **13 years old** to use the Service. If you are using the Service on behalf of a Forest or organization, you represent that you have authority to bind that entity to these Terms.
+You must be at least **13 years old** to use the Service. If you are using the service on behalf a company, organization, or other legal entity, you represent that you have authority to bind that entity to these Terms.
 
 
 ## 2. Accounts & Security
@@ -18,7 +18,7 @@ You may need an account to use some features. You’re responsible for keeping y
 
 ## 3. Software License (CLI & Plugin)
 
-Subject to these Terms, Forest grants you a limited, revocable, non‑exclusive, non‑transferable license to install and use the CLI and plugin solely to build with and for the Service. You may not: (a) copy, modify, or create derivative works of the software; (b) reverse engineer or attempt to extract source code except where permitted by law; (c) bypass, remove, or circumvent any security or technical measures; (d) resell, rent, or lease the Service unless we give you written permission.
+Subject to these Terms, Forest Software grants you a limited, revocable, non‑exclusive, non‑transferable license to install and use the CLI and plugin solely to build with and for the Service. You may not: (a) copy, modify, or create derivative works of the software; (b) reverse engineer or attempt to extract source code except where permitted by law; (c) bypass, remove, or circumvent any security or technical measures; (d) resell, rent, or lease the Service unless we give you written permission.
 
 
 ## 4. Third‑Party Services & APIs
@@ -29,13 +29,18 @@ The Service may interact with third‑party platforms and APIs (e.g., **Roblox**
 ## 5. User Content
 
 **Ownership.** You retain ownership of code, assets, and other content you submit or upload through the Service (“User Content”).  
-**License to Us.** You grant Forest a non‑exclusive, worldwide, royalty‑free license to host, store, process, transmit, and display your User Content **solely to provide and operate** the Service and as you otherwise instruct (e.g., sharing or distribution features you use).  
+
+**License to Us.** You grant Forest Software a non‑exclusive, worldwide, royalty‑free license to host, store, process, transmit, and display your User Content **solely to provide and operate** the Service and as you otherwise instruct (e.g., sharing or distribution features you use).
+
 **Your Responsibilities.** You are responsible for your User Content and for ensuring you have the rights to submit it. Do not upload content that is illegal or that infringes others’ rights.  
-**Visibility & Org Access.** If you use an organization account, designated org admins may access audit logs and certain usage information associated with your account as described in our Privacy Policy.
+
+**Visibility & Org Access.** If you use an organization account, designated org admins may access audit logs and certain usage information associated with your account as described in our [Privacy Policy](/legal/privacy-policy).
+
+**Atribution & Public Record.** When you upload or publish a package, your username becomes part of the permanent public record for that package. This information may continue to be displayed and retained even if your account is later deleted, as it is necessary for the integrity, attribution, and traceability of the software ecosystem.
 
 ## 5.1 Use of AI Services
 
-We use third-party AI providers (such as OpenAI) to process package metadata, including but not limited to package names, descriptions, and README files. This processing is done only for public packages and is used to improve search, discovery, and recommendations within Forest. By uploading a public package, you grant Forest a non-exclusive, worldwide license to analyze and process its metadata for these purposes. This license is limited to enabling functionality within Forest and does not authorize us or our AI providers to redistribute or commercialize your content beyond what is necessary to provide the service. You are responsible for ensuring that your submissions (including README and metadata) do not infringe on third-party rights, contain sensitive personal information, or otherwise violate applicable laws or these Terms. Private packages are never sent to external AI providers.
+We use third-party AI providers (such as OpenAI) to process package metadata, including but not limited to package names, descriptions, and README files. This processing is done only for public packages and is used to improve search, discovery, and recommendations within Forest Software. By uploading a public package, you grant Forest Software a non-exclusive, worldwide license to analyze and process its metadata for these purposes. This license is limited to enabling functionality within Forest Software and does not authorize us or our AI providers to redistribute or commercialize your content beyond what is necessary to provide the service. You are responsible for ensuring that your submissions (including README and metadata) do not infringe on third-party rights, contain sensitive personal information, or otherwise violate applicable laws or these Terms. Private packages are never sent to external AI providers.
 
 
 ## 6. Acceptable Use
@@ -47,7 +52,7 @@ You agree not to misuse the Service. For example, you will not: (a) violate laws
 
 We **do not pre-screen** User Content before it is made available. Instead, we provide community reporting tools — including a form to report packages — and may use automated filters to flag obvious abuse.
 
-We may remove or disable access to any content, or suspend or terminate accounts, where we in good faith believe these Terms, our Acceptable Use Policy, or applicable law are violated (including repeat infringement under Section 10).
+We may remove or disable access to any content, or suspend or terminate accounts, where we in good faith believe these Terms, our Acceptable Use Policy, or applicable law are violated (including repeat infringement under Section 9).
 
 We are **not obligated to monitor all content** and make no guarantees that all objectionable or unlawful content will be removed. Users are encouraged to use the reporting tools to help us maintain a safe and compliant environment.
 
@@ -74,7 +79,7 @@ please submit a notice to our designated DMCA Agent:
 **Phone:** +1-505-715-5700  
 **Email:** [LegalResponseTeam@L4SB.com](mailto:LegalResponseTeam@L4SB.com)  
 
-Pursuant to 17 U.S.C. §512(c), Forest has designated the above agent to receive
+Pursuant to 17 U.S.C. §512(c), Forest Software has designated the above agent to receive
 notifications of alleged infringement. This contact information is also registered
 with the U.S. Copyright Office.
 
@@ -85,12 +90,16 @@ For more information, see our [DMCA Policy](/legal/dmca).
 
 ## 10. Intellectual Property (Ours)
 
-The Service, software, documentation, and brand assets are owned by Forest and its licensors. Except for the limited license in Section 5, we grant no rights to our IP. Feedback is voluntary; we may use it without restriction.
+The Service, software, documentation, and brand assets are owned by Forest Software and its licensors. Except for the limited license in Section 3, we grant no rights to our IP. 
+
+Use of Forest Software trademarks, logos, or other brand assets requires prior written permission from Forest Software.
+
+Feedback is voluntary; we may use it without restriction.
 
 
 ## 11. Termination
 
-You may stop using the Service at any time. We may suspend or terminate your access immediately if you materially breach these Terms, create risk or possible legal exposure for us, or use the Service in a way that could disrupt others. Upon termination, your right to use the Service ends, but Sections 5, 6 (as to licenses needed to operate the Service, e.g., limited back‑ups), 9–20 survive.
+You may stop using the Service at any time. We may suspend or terminate your access immediately if you materially breach these Terms, create risk or possible legal exposure for us, or use the Service in a way that could disrupt others. Upon termination, your right to use the Service ends, but Sections 5–5.1, 8–10, and 12–16 (including any limited licenses needed to operate the Service, e.g., backups) will survive termination.
 
 
 ## 12. Disclaimers
@@ -100,12 +109,12 @@ THE SERVICE IS PROVIDED **“AS IS”** AND **“AS AVAILABLE.”** TO THE MAXIM
 
 ## 13. Limitation of Liability
 
-TO THE MAXIMUM EXTENT PERMITTED BY LAW, Forest AND ITS AFFILIATES, SUPPLIERS, AND LICENSORS WILL NOT BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, OR ANY LOSS OF PROFITS, REVENUE, DATA, OR USE, EVEN IF ADVISED OF THE POSSIBILITY. OUR AGGREGATE LIABILITY FOR ALL CLAIMS RELATING TO THE SERVICE WILL NOT EXCEED THE GREATER OF **(A) THE AMOUNTS YOU PAID TO US FOR THE SERVICE IN THE 12 MONTHS BEFORE THE CLAIM** OR **(B) US $100.** Some jurisdictions don’t allow certain limits; these may not apply to you.
+TO THE MAXIMUM EXTENT PERMITTED BY LAW, Forest Software AND ITS AFFILIATES, SUPPLIERS, AND LICENSORS WILL NOT BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, OR ANY LOSS OF PROFITS, REVENUE, DATA, OR USE, EVEN IF ADVISED OF THE POSSIBILITY. OUR AGGREGATE LIABILITY FOR ALL CLAIMS RELATING TO THE SERVICE WILL NOT EXCEED THE GREATER OF **(A) THE AMOUNTS YOU PAID TO US FOR THE SERVICE IN THE 12 MONTHS BEFORE THE CLAIM** OR **(B) US $100.** Some jurisdictions don’t allow certain limits; these may not apply to you.
 
 
 ## 14. Indemnity
 
-You will indemnify and hold Forest harmless from any claim arising from your use of the Service or User Content that violates law or third‑party rights.
+You will indemnify and hold Forest Software harmless from any claim arising from your use of the Service or User Content that violates law or third‑party rights.
 
 
 ## 15. Export & Sanctions
@@ -117,7 +126,7 @@ You may not use the Service if you are located in, or are a resident of, a count
 
 These Terms are governed by the laws of the State of Texas, USA, without regard to conflict-of-laws rules.  
 
-You and Forest consent to Travis County, Texas as the exclusive venue for any permitted court proceedings.  
+You and Forest Software consent to Travis County, Texas as the exclusive venue for any permitted court proceedings.  
 
 
 ## 17. Changes to the Service or Terms
@@ -127,7 +136,7 @@ We may modify the Service and these Terms. For material changes, we will provide
 
 ## 18. Contact
 
-Forest Sofware LLC
+Forest Software, LLC <br />
 5900 Balcones Dr, STE 100 <br />
 Austin, TX 78731 <br />
 Email: [hi@forest.dev](mailto:hi@forest.dev)

--- a/src/content/legal/terms.mdx
+++ b/src/content/legal/terms.mdx
@@ -80,7 +80,7 @@ with the U.S. Copyright Office.
 
 Your notice must include the required information under 17 U.S.C. § 512(c)(3).
 We may remove or disable access to reported content and may terminate repeat infringers.
-For more information, see our [DMCA Takedown Policy](/policies/dmca).
+For more information, see our [DMCA Takedown Policy](/legal/dmca).
 
 
 ## 10. Intellectual Property (Ours)

--- a/src/content/legal/terms.mdx
+++ b/src/content/legal/terms.mdx
@@ -50,7 +50,7 @@ You agree not to misuse the Service. For example, you will not: (a) violate laws
 
 ## 7. Moderation & Reporting
 
-We **do not pre-screen** User Content before it is made available. Instead, we provide community reporting tools — including a form to report packages — and may use automated filters to flag obvious abuse.
+We **do not pre-screen** User Content before it is made available. Instead, we provide community reporting tools -- including a form to report packages -- and may use automated filters to flag obvious abuse.
 
 We may remove or disable access to any content, or suspend or terminate accounts, where we in good faith believe these Terms, our Acceptable Use Policy, or applicable law are violated (including repeat infringement under Section 9).
 

--- a/src/content/packages/create.mdx
+++ b/src/content/packages/create.mdx
@@ -5,7 +5,7 @@ import { Steps } from 'nextra/components'
 
 # Creating & Updating a Package
 
-This section will cover how to create and upload your own packages to the Forest Package Manager.
+This section will cover how to create and upload your own packages to Forest.
 
 ## Prerequisites
 
@@ -15,7 +15,7 @@ Before you can create and upload packages, you'll need to have the following:
 
 ## Creating a Package
 
-Lets say we want to create a package that provides a simple "Hello World" function.
+Let's say we want to create a package that provides a simple "Hello World" function.
 
 <Steps>
 ### Create a new directory for your package
@@ -48,7 +48,7 @@ forest init
 
 After selecting the appropriate options, this will create a `forest.json` file in our package directory.
 
-This file contains metadata about our package, such as its name, version, and description. You should never need to manually edit this file, as the Forest CLI will handle it for you.
+This file contains metadata about our package, such as its name, version, and description. In most cases, you won't need to manually edit this file.
 
 ### Publish to Forest Package Manager
 
@@ -56,7 +56,7 @@ This file contains metadata about our package, such as its name, version, and de
 forest publish
 ```
 
-This command will upload our package to the Forest Package Manager, making it available for others to install and use.
+This command will upload our package to Forest, making it available for others to install and use.
 If this is your first time publishing a package, you'll be prompted to log in to your Forest PM account.
 
 The CLI will ask you a few questions about your package, such as its visibility (public or private), name, description, version and License type.
@@ -73,12 +73,12 @@ forest i @forest/utils
 
 Then, when we publish our package, the Forest CLI will automatically detect the dependency and include it in the `forest.json` file.
 
-When someone installs your package, the package manager will automatically install any dependencies it has. 
+When someone installs your package, Forest will automatically install any dependencies it has. 
 
 <Callout type="warning">
   Packages with dependencies will always have their `/package` folder at the same level as the `init` file.
   For example, if your `init` file is located at `my-package/src/init.lua`, your dependencies will be installed to `my-package/src/packages/`.
-  This is to ensure that your package can always find its dependencies, regardless of where the `init` file is located.
+  This ensures your package can always find its dependencies, regardless of project structure
 
   For Rojo users, `default.project.json` will be ignored.
 </Callout>

--- a/src/content/packages/create.mdx
+++ b/src/content/packages/create.mdx
@@ -73,7 +73,7 @@ forest i @forest/utils
 
 Then, when we publish our package, the Forest CLI will automatically detect the dependency and include it in the `forest.json` file.
 
-When someone installs your package, Forest PM will automatically install any dependencies it has. 
+When someone installs your package, Forest PM will automatically install any of its dependencies. 
 
 <Callout type="warning">
   Packages with dependencies will always have their `/package` folder at the same level as the `init` file.

--- a/src/content/packages/create.mdx
+++ b/src/content/packages/create.mdx
@@ -5,13 +5,13 @@ import { Steps } from 'nextra/components'
 
 # Creating & Updating a Package
 
-This section will cover how to create and upload your own packages to Forest.
+This section will cover how to create and upload your own packages to Forest PM.
 
 ## Prerequisites
 
 Before you can create and upload packages, you'll need to have the following:
 - A [Forest PM account](https://forest.dev)
-- [Forest CLI installed](https://docs.forest.dev/cli/installation)
+- [Forest CLI installed](https://docs.forest.dev/forest-cli/install)
 
 ## Creating a Package
 
@@ -56,7 +56,7 @@ This file contains metadata about our package, such as its name, version, and de
 forest publish
 ```
 
-This command will upload our package to Forest, making it available for others to install and use.
+This command will upload our package to Forest PM, making it available for others to install and use.
 If this is your first time publishing a package, you'll be prompted to log in to your Forest PM account.
 
 The CLI will ask you a few questions about your package, such as its visibility (public or private), name, description, version and License type.
@@ -73,7 +73,7 @@ forest i @forest/utils
 
 Then, when we publish our package, the Forest CLI will automatically detect the dependency and include it in the `forest.json` file.
 
-When someone installs your package, Forest will automatically install any dependencies it has. 
+When someone installs your package, Forest PM will automatically install any dependencies it has. 
 
 <Callout type="warning">
   Packages with dependencies will always have their `/package` folder at the same level as the `init` file.
@@ -87,6 +87,6 @@ When someone installs your package, Forest will automatically install any depend
 ### Updating a Package
 To update your package, simply make changes to your code, then run the `forest publish` command again.
 
-The CLI will automatically increment the version number based on the changes you made (major, minor, or patch), and upload the new version to the Forest Package Manager.
+The CLI will automatically increment the version number based on the changes you made (major, minor, or patch), and upload the new version to Forest PM.
 
 For more information about how Forest PM handles versioning, see the [SemVer](https://semver.org/) guidelines.

--- a/src/content/packages/intro.mdx
+++ b/src/content/packages/intro.mdx
@@ -1,5 +1,7 @@
 ## What is a "Package"?
 
+> **TODO:** Break intro into 2 subsections that show on the left navigation column: "What is Forest?" & "Core Features"
+
 Packages have been used in software development for decades, and are a core part of modern development workflows, but to many in the virtual experience space, packages and package managers are a new concept.
 
 A package is a bundle of code that accomplishes a specific task. Packages can be as small as a single function, or as large as an entire framework.

--- a/src/content/packages/intro.mdx
+++ b/src/content/packages/intro.mdx
@@ -1,8 +1,6 @@
 ## What is a "Package"?
 
-> **TODO:** Break intro into 2 subsections that show on the left navigation column: "What is Forest?" & "Core Features"
-
-Packages have been used in software development for decades, and are a core part of modern development workflows, but to many in the virtual experience space, packages and package managers are a new concept.
+Packages have been used in software development for decades. They are a core part of modern development workflows, but to many in the virtual experience space, packages and package managers are a new concept.
 
 A package is a bundle of code that accomplishes a specific task. Packages can be as small as a single function, or as large as an entire framework.
 As an analogy, think of making spaghetti. You need several ingredients to make spaghetti, such as pasta, sauce, and meatballs. Each of these ingredients can be thought of as a package.

--- a/src/content/packages/intro.mdx
+++ b/src/content/packages/intro.mdx
@@ -1,6 +1,6 @@
 ## What is a "Package"?
 
-Packages have been used in software development for decades, and are a core part of modern development workflows, but to many in the immersive experience space, packages and package managers are a new concept.
+Packages have been used in software development for decades, and are a core part of modern development workflows, but to many in the virtual experience space, packages and package managers are a new concept.
 
 A package is a bundle of code that accomplishes a specific task. Packages can be as small as a single function, or as large as an entire framework.
 As an analogy, think of making spaghetti. You need several ingredients to make spaghetti, such as pasta, sauce, and meatballs. Each of these ingredients can be thought of as a package.

--- a/src/content/packages/intro.mdx
+++ b/src/content/packages/intro.mdx
@@ -5,7 +5,7 @@ Packages have been used in software development for decades. They are a core par
 A package is a bundle of code that accomplishes a specific task. Packages can be as small as a single function, or as large as an entire framework.
 As an analogy, think of making spaghetti. You need several ingredients to make spaghetti, such as pasta, sauce, and meatballs. Each of these ingredients can be thought of as a package.
 
-Developing games without a package manager is like making spaghetti from scratch - you have to gather, or "re-invent" all the ingredients yourself, which can be time-consuming and error-prone.
+Developing games without a package manager is like making spaghetti from scratch -- you have to gather, or "re-invent" all the ingredients yourself, which can be time-consuming and error-prone.
 
 ### Modern Development Challenges Without Packages
 - **Re-inventing the wheel**: Without packages, developers often have to write code for common tasks that have already been solved by others. This leads to duplicated effort and wasted time.

--- a/src/content/packages/usage.mdx
+++ b/src/content/packages/usage.mdx
@@ -12,11 +12,11 @@ Before you can create and upload packages, you'll need to have the [Forest CLI](
 
 ## Installing Packages
 
-For this example, we'll be making spaghetti. To make spaghetti, we need 3 ingredients: pasta, sauce, and meatballs.
+For this metaphorical example, we'll be cooking (coding) spaghetti. To make spaghetti, we need to grab (install) 3 ingredients (packages): pasta, sauce, and meatballs.
 
-Lets say we found 3 packages that provide these ingredients: `@forest/pasta`, `@user1/sauce`, and `@user1/meatballs`.
+Lets say you found 3 packages that provide these ingredients: `@forest/pasta`, `@user1/sauce`, and `@user1/meatballs`.
 
-We'll cover the install commands in detail later, but for now, we'll use the following commands to install these packages:
+We'll cover the install commands in detail later, but for now, use the following to install the packages:
 
 ```bash
 forest i @forest/pasta
@@ -24,13 +24,13 @@ forest i @user1/sauce
 forest i @user1/meatballs
 ```
 
-Now that we have our ingredients installed, we can import them into our project and start building.
+Now that we have our ingredients installed, we can import them into our project and start cooking.
 ```lua
 local Pasta = require("pasta")
 local Sauce = require("sauce")
 local Meatballs = require("meatballs")
 
--- Do something with our now imported ingredients
+-- Do something with our now-imported ingredients
 ```
 
 Using packages this way means every part of your project stays modular. You can update, replace, or share each “ingredient” without breaking the rest of your code.
@@ -74,10 +74,12 @@ Since we didn’t install flour directly, it doesn’t appear in the root packag
 This structure keeps dependencies isolated. Each package manages its own requirements without affecting the main project or other packages. If you do want to use flour directly, you can install it yourself with:
 `forest i @forest/flour`
 
+> **TODO:** Alex suggests that FAQs becomes its own following subsections
+
 ## Commonly Asked Questions
 > What happens if two packages depend on the same package?
 
-Forest uses a technique called "dependency deduplication" to ensure that if multiple packages depend on the same package, only one copy of that package is installed. This helps to reduce disk space usage and avoid version conflicts.
+Forest uses a technique called "dependency de-duplication" to ensure that if multiple packages depend on the same package, only one copy of that package is installed. This helps to reduce disk space usage and avoid version conflicts.
 
 > What if two packages depend on different versions of the same package?
 

--- a/src/content/packages/usage.mdx
+++ b/src/content/packages/usage.mdx
@@ -24,8 +24,7 @@ forest i @user1/sauce
 forest i @user1/meatballs
 ```
 
-Now that we have our ingredients installed, developers can use these packages in their code.
-
+Now that we have our ingredients installed, we can import them into our project and start building.
 ```lua
 local Pasta = require("pasta")
 local Sauce = require("sauce")
@@ -34,13 +33,13 @@ local Meatballs = require("meatballs")
 -- Do something with our now imported ingredients
 ```
 
-Its that easy! The package manager handles downloading the packages, as well as any dependencies they may have, so you can focus on building your project.
-
+Using packages this way means every part of your project stays modular. You can update, replace, or share each “ingredient” without breaking the rest of your code.
 ## Package Dependencies
 
-When you install a package, the package manager will also install any dependencies that package has. For example, if `@forest/pasta` relies on a package called `@forest/flour`, the package manager will automatically install `@forest/flour` when you install `@forest/pasta`.
-
-When this happens, its likely your project's file tree will look something like this:
+When you install a package, Forest automatically installs any dependencies it requires.
+For example, if `@forest/pasta` depends on `@forest/flour`, Forest installs both packages when you run: `forest i @forest/pasta
+`
+After installation, your project’s file tree will look like this:
 
 <FileTree>
   <FileTree.Folder name="my-project" defaultOpen>
@@ -68,16 +67,17 @@ When this happens, its likely your project's file tree will look something like 
   </FileTree.Folder>
 </FileTree>
 
-Notice how the top-most `packages` folder contains the 3 packages we installed, and the `pasta` package contains a `packages` folder with its dependency, `flour`.
+In the example file tree, the root `packages` folder contains the three packages we installed. Inside the `pasta` package, there’s another `packages` folder with its dependency, `flour`.
 
-Because we didn't install flour directly, it doesn't appear in the top-most packages folder, meaning its not a package we can directly use in our project.
+Since we didn’t install flour directly, it doesn’t appear in the root packages folder. That means it isn’t available for you to require() in your project.
 
-This structure allows packages to have their own dependencies without causing conflicts with other packages or the main project. In the event we wanted to access flour directly, we could install it ourselves using `forest i @forest/flour`, which would add it to the top-most packages folder.
+This structure keeps dependencies isolated. Each package manages its own requirements without affecting the main project or other packages. If you do want to use flour directly, you can install it yourself with:
+`forest i @forest/flour`
 
-## Common Questions
+## Commonly Asked Questions
 > What happens if two packages depend on the same package?
 
-Forest package manager uses a technique called "dependency deduplication" to ensure that if multiple packages depend on the same package, only one copy of that package is installed. This helps to reduce disk space usage and avoid version conflicts.
+Forest uses a technique called "dependency deduplication" to ensure that if multiple packages depend on the same package, only one copy of that package is installed. This helps to reduce disk space usage and avoid version conflicts.
 
 > What if two packages depend on different versions of the same package?
 
@@ -87,7 +87,7 @@ This allows each package to use the version it was designed to work with, preven
 
 > What happens if I install 2 packages with the same name?
 
-If you attempt to install two packages with the same name but from different authors or sources, the package manager will treat them as separate entities based on their full package identifiers (which typically include the author's namespace).
+If you attempt to install two packages with the same name but from different authors or sources, Forest will treat them as separate entities based on their full package identifiers (which typically include the author's namespace).
 
 This means you can have `@user1/package` and `@user2/package` installed simultaneously without conflict, as they are considered distinct packages.
 

--- a/src/content/packages/usage.mdx
+++ b/src/content/packages/usage.mdx
@@ -8,7 +8,7 @@ This section will cover how to use packages in your project's workflow.
 
 ### Prerequisites
 
-Before you can create and upload packages, you'll need to have the [Forest CLI](/cli/installation) installed.
+Before you can create and upload packages, you'll need to have the [Forest CLI](/forest-cli/install) installed.
 
 ## Installing Packages
 
@@ -33,12 +33,11 @@ local Meatballs = require("meatballs")
 -- Do something with our now-imported ingredients
 ```
 
-Using packages this way means every part of your project stays modular. You can update, replace, or share each “ingredient” without breaking the rest of your code.
+Using packages this way means every part of your project stays modular. You can update, replace, or share each “ingredient”, allowing you to update or replace packages with ease.
 ## Package Dependencies
 
-When you install a package, Forest automatically installs any dependencies it requires.
-For example, if `@forest/pasta` depends on `@forest/flour`, Forest installs both packages when you run: `forest i @forest/pasta
-`
+When you install a package, Forest PM automatically installs any dependencies it requires.
+For example, if `@forest/pasta` depends on `@forest/flour`, Forest PM installs both packages when you run: <br /> `forest i @forest/pasta`
 After installation, your project’s file tree will look like this:
 
 <FileTree>
@@ -71,30 +70,5 @@ In the example file tree, the root `packages` folder contains the three packages
 
 Since we didn’t install flour directly, it doesn’t appear in the root packages folder. That means it isn’t available for you to require() in your project.
 
-This structure keeps dependencies isolated. Each package manages its own requirements without affecting the main project or other packages. If you do want to use flour directly, you can install it yourself with:
+This structure keeps dependencies isolated. Each package manages its own requirements without affecting the main project or other packages. If you do want to use flour directly, you can install it yourself with: <br />
 `forest i @forest/flour`
-
-> **TODO:** Alex suggests that FAQs becomes its own following subsections
-
-## Commonly Asked Questions
-> What happens if two packages depend on the same package?
-
-Forest uses a technique called "dependency de-duplication" to ensure that if multiple packages depend on the same package, only one copy of that package is installed. This helps to reduce disk space usage and avoid version conflicts.
-
-> What if two packages depend on different versions of the same package?
-
-In cases where two packages depend on different versions of the same package, the package manager will install both versions in separate folders within the `packages` directory. 
-
-This allows each package to use the version it was designed to work with, preventing compatibility issues. However, this can lead to increased disk space usage, so it's generally recommended to use packages that depend on compatible versions of shared dependencies whenever possible.
-
-> What happens if I install 2 packages with the same name?
-
-If you attempt to install two packages with the same name but from different authors or sources, Forest will treat them as separate entities based on their full package identifiers (which typically include the author's namespace).
-
-This means you can have `@user1/package` and `@user2/package` installed simultaneously without conflict, as they are considered distinct packages.
-
-Importing those packages will require using their full names to avoid ambiguity:
-
-```lua
-local Package1 = require("user1_package")
-local Package2 = require("user2_package")


### PR DESCRIPTION
- Updated wording and tone across all docs for clarity and flow.
- Standardized naming conventions for product references:
  - “Forest” for the platform.
  - “Forest CLI” when referring to the command-line tool.
  - “Forest Package Manager” used only in introductory contexts.
- Adjusted introductory sections to better explain Forest’s value and workflow
- Polished examples and analogies for clarity
- small grammatical errors